### PR TITLE
PLT-7680 Created executable for testing arbitrary Marlowe validators.

### DIFF
--- a/changelog.d/20231019_125415_brian.bush_PLT_7680.md
+++ b/changelog.d/20231019_125415_brian.bush_PLT_7680.md
@@ -1,0 +1,3 @@
+### Added
+
+- Executable `marlowe-plutus-tester` for testing externally-provided Marlowe validators.

--- a/marlowe-plutus/MarlowePlutusTester.md
+++ b/marlowe-plutus/MarlowePlutusTester.md
@@ -1,0 +1,78 @@
+# Manually Testing a Marlowe Validator
+
+The executable `marlowe-plutus-tester` runs the tests for conformance of an externally-supplied pair of Marlowe validators to the [Marlowe-Cardano Specification](https://github.com/input-output-hk/marlowe-cardano/blob/main/marlowe/specification/ReadMe.md).
+
+
+## Usage
+
+The `marlowe-plutus-tester` requires at least two arguments:
+
+- The serialized Cardano text-envelope file for a Plutus V2 Marlowe semantics validator.
+- The serialized Cardano text-envelope file for a Plutus V2 Marlowe role-payout validator.
+- Any `hspec` flags to modify which tests are run.
+
+
+## Example
+
+```console
+$ cabal run marlowe-plutus-tester -- marlowe-semantics.plutus marlowe-rolepayout.plutus
+
+Marlowe validator
+  Should be a reasonable size [✔]
+  Valid transactions
+    Noiseless [✔]
+      +++ OK, passed 100 tests.
+    Noisy [✔]
+      +++ OK, passed 100 tests.
+  Constraint 2. Single Marlowe script input [✔]
+    +++ OK, passed 100 tests.
+  Constraint 3. Single Marlowe output [✔]
+    +++ OK, passed 100 tests.
+  Constraint 4. No output to script on close [✔]
+    +++ OK, passed 100 tests.
+  Constraint 5. Input value from script [✔]
+    +++ OK, passed 100 tests.
+  Constraint 6. Output value to script [✔]
+    +++ OK, passed 100 tests.
+  Constraint 9. Marlowe parameters [✔]
+    +++ OK, passed 100 tests.
+  Constraint 10. Output state [✔]
+    +++ OK, passed 100 tests.
+  Constraint 11. Output contract [✔]
+    +++ OK, passed 100 tests.
+  Constraint 12. Merkleized continuations
+    Valid merkleization [✔]
+      +++ OK, passed 100 tests.
+    Invalid merkleization [✔]
+      +++ OK, passed 100 tests.
+  Constraint 13. Positive balances [✔]
+    +++ OK, passed 100 tests.
+  Constraint 14. Inputs authorized [✔]
+    +++ OK, passed 100 tests.
+  Constraint 15. Sufficient payment [✔]
+    +++ OK, passed 100 tests.
+  Constraint 18. Final balance [✔]
+    +++ OK, passed 100 tests.
+  Constraint 19. No duplicates [✔]
+    +++ OK, passed 100 tests.
+  Constraint 20. Single satisfaction [✔]
+    +++ OK, passed 100 tests.
+  Hash golden test [✔]
+    +++ OK, passed 1 test.
+Payout validator
+  Valid transactions
+    Noiseless [✔]
+      +++ OK, passed 100 tests.
+    Noisy [✔]
+      +++ OK, passed 100 tests.
+  Constraint 17. Payment authorized
+    Invalid authorization for withdrawal [✔]
+      +++ OK, passed 100 tests.
+    Missing authorized withdrawal [✔]
+      +++ OK, passed 100 tests.
+  Hash golden test [✔]
+    +++ OK, passed 1 test.
+
+Finished in 56.4699 seconds
+25 examples, 0 failures
+```

--- a/marlowe-plutus/marlowe-plutus.cabal
+++ b/marlowe-plutus/marlowe-plutus.cabal
@@ -138,9 +138,43 @@ test-suite marlowe-plutus
     , bytestring
     , cardano-api
     , containers
+    , data-default
     , directory
     , filepath
     , hspec
+    , lens
+    , marlowe-cardano
+    , marlowe-plutus
+    , marlowe-test ^>=0.1
+    , plutus-ledger-api
+    , plutus-tx
+    , QuickCheck
+    , serialise
+    , transformers
+
+  build-tool-depends: hspec-discover:hspec-discover
+  ghc-options:        -threaded
+
+executable marlowe-plutus-tester
+  import:             lang
+  hs-source-dirs:     test
+  main-is:            Main.hs
+  other-modules:
+    Language.Marlowe.PlutusSpec
+    Paths_marlowe_plutus
+
+  build-depends:
+    , aeson
+    , base
+    , bytestring
+    , cardano-api
+    , cardano-crypto-class
+    , containers
+    , data-default
+    , directory
+    , filepath
+    , hspec
+    , hspec-core
     , lens
     , marlowe-cardano
     , marlowe-plutus

--- a/marlowe-plutus/test/Main.hs
+++ b/marlowe-plutus/test/Main.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main (
+  main,
+) where
+
+import qualified Cardano.Api as C
+import qualified Cardano.Api.Shelley as C
+import qualified Cardano.Crypto.Hash as Hash
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
+import Language.Marlowe.PlutusSpec (ScriptsInfo (..), specForScript)
+import qualified Plutus.V1.Ledger.Address as P (scriptHashAddress)
+import qualified Plutus.V2.Ledger.Api as P
+import System.Environment (getArgs)
+import Test.Hspec.Core.Runner (
+  defaultConfig,
+  evaluateSummary,
+  readConfig,
+  runSpec,
+ )
+
+main :: IO ()
+main =
+  getArgs
+    >>= \case
+      semanticsFile : payoutFile : flags ->
+        do
+          scripts <- mkScriptsInfo semanticsFile payoutFile
+          config <- readConfig defaultConfig flags
+          summary <- flip runSpec config $ specForScript scripts
+          evaluateSummary summary
+      _ ->
+        putStrLn
+          "USAGE: marlowe-plutus <semantics validator text envelope file> <payoutValidator text envelope file> [hspec flags]"
+
+mkScriptsInfo
+  :: FilePath
+  -> FilePath
+  -> IO ScriptsInfo
+mkScriptsInfo semanticsFile payoutFile =
+  do
+    (semanticsValidatorBytes, semanticsValidatorHash, semanticsAddress) <- readScript semanticsFile
+    (payoutValidatorBytes, payoutValidatorHash, payoutAddress) <- readScript payoutFile
+    pure ScriptsInfo{..}
+
+readScript
+  :: FilePath
+  -> IO (P.SerializedScript, P.ValidatorHash, P.Address)
+readScript file =
+  do
+    validatorBytes <-
+      C.readFileTextEnvelope (C.AsPlutusScript C.AsPlutusScriptV2) file
+        >>= \case
+          Right (C.PlutusScriptSerialised plutus) -> pure plutus
+          Left e -> error $ "Error parsing validator file " <> show file <> ": " <> show e
+    let validatorHash = hashScript validatorBytes
+        address = P.scriptHashAddress validatorHash
+    pure (validatorBytes, validatorHash, address)
+
+hashScript
+  :: P.SerializedScript
+  -> P.ValidatorHash
+hashScript =
+  P.ValidatorHash
+    . P.toBuiltin
+    . (Hash.hashToBytes :: Hash.Hash Hash.Blake2b_224 SBS.ShortByteString -> BS.ByteString)
+    . Hash.hashWith (BS.append "\x02" . SBS.fromShort) -- For Plutus V2.


### PR DESCRIPTION
The `marlowe-plutus-tester` executable runs the Marlowe-Cardano Specification tests on the Marlowe semantics and role-payout validators.

Its usage is [documented here](https://github.com/input-output-hk/marlowe-plutus/blob/PLT-7680/marlowe-plutus/MarlowePlutusTester.md).