### PR TITLE
Update nix documentation the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,9 @@ the spending of role payouts.
 
 This repository uses nix to provide the development and build environment.
 
-If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
-the flake config values to enable access to our binary caches.   
+For instructions on how to install and configure nix (including how to enable access to our binary caches), refer to [this document](https://github.com/input-output-hk/iogx/blob/main/doc/nix-setup-guide.md). 
 
-The nix code is based on a template from the 
-[IOGX flake](https://github.com/input-output-hk/iogx). 
-For instructions on how to install and configure nix (including how to enable 
-access to our binary caches), and how keep the flake inputs up to date, refer to 
-[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
-of the IOGX manual.
+If you already have nix installed and configured, you may enter the development shell by running `nix develop`.
 
 If you have direnv installed, you can have the shell automatically load and 
 refresh for you by running these commands:

--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ the spending of role payouts.
 
 ## Dev Shell
 
-To enter a dev shell with all dependencies installed, you can use
+This repository uses nix to provide the development and build environment.
 
-```bash
-nix develop
-```
+If you know nix, simply run `nix develop` to enter the shell; if prompted, trust 
+the flake config values to enable access to our binary caches.   
 
-Alternatively, if you have direnv installed, you can have the shell
-automatically load and refresh for you by running these commands:
+The nix code is based on a template from the 
+[IOGX flake](https://github.com/input-output-hk/iogx). 
+For instructions on how to install and configure nix (including how to enable 
+access to our binary caches), and how keep the flake inputs up to date, refer to 
+[this section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix)
+of the IOGX manual.
+
+If you have direnv installed, you can have the shell automatically load and 
+refresh for you by running these commands:
 
 ```bash
 mkdir .direnv
@@ -37,7 +43,7 @@ Alternatively, you can compile with `nix` using `nix build .#marlowe-validators`
 You can compile the validators using the following command:
 
 ```bash
-nix build .#validators
+nix build .#marlowe-validators
 ```
 
 This will build the project and run the `marlowe-validators` executable and

--- a/flake.lock
+++ b/flake.lock
@@ -510,11 +510,11 @@
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1699460731,
-        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
+        "lastModified": 1699537966,
+        "narHash": "sha256-MGGza+vZDRjKj31WhQJDt7CqVVdrFkgkXIcqr0gDiU8=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
+        "rev": "c6ce7f034717ed0c0e9c6dd8fa2f898a15439627",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -505,15 +505,16 @@
         "nixpkgs": [
           "nixpkgs"
         ],
+        "nixpkgs-stable": "nixpkgs-stable",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock"
       },
       "locked": {
-        "lastModified": 1698059777,
-        "narHash": "sha256-0e7HvCbEridOf2yxjVhiZLVSl6dNoWlxd/fq1/Mtexg=",
+        "lastModified": 1699460731,
+        "narHash": "sha256-WhMr0HPj1T+2lvH3Yh+fJq79MXYPnXofQ805JnQmI3k=",
         "owner": "input-output-hk",
         "repo": "iogx",
-        "rev": "a504383df278b9160b673b1ae9e5c483b155352c",
+        "rev": "63deb643d7dfac8bf06b0d357caca742bd53ae07",
         "type": "github"
       },
       "original": {
@@ -730,6 +731,22 @@
     },
     "nixpkgs-stable": {
       "locked": {
+        "lastModified": 1690680713,
+        "narHash": "sha256-NXCWA8N+GfSQyoN7ZNiOgq/nDJKOp5/BHEpiZP8sUZw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b81af66deb21f73a70c67e5ea189568af53b1e8c",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
+      "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
@@ -799,7 +816,7 @@
         "flake-utils": "flake-utils_3",
         "gitignore": "gitignore",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
         "lastModified": 1696846637,


### PR DESCRIPTION
Instructions on how to install & upgrade nix and how to setup the binary caches are now included in the [relevant section](https://github.com/input-output-hk/iogx/blob/main/doc/api.md#flakenix) of the IOGX manual. 
This PR updates various files and documents that reference nix. 
