### PR TITLE
PLT-7584 Flags for validator checks

### DIFF
--- a/marlowe-plutus/cost-measurements/.gitignore
+++ b/marlowe-plutus/cost-measurements/.gitignore
@@ -1,0 +1,7 @@
+out/
+*.tsv
+.RData
+*.Rout
+*.dot
+*.svg
+*.png

--- a/marlowe-plutus/cost-measurements/ReadMe.md
+++ b/marlowe-plutus/cost-measurements/ReadMe.md
@@ -1,0 +1,3 @@
+# Measuring Plutus Costs of Cabal Flags
+
+Run [measure.sh](./measure.sh) in this folder in the Nix developer shell to generate data files and plots of Plutus costs as a function of various compiler flags for the benchmark of 100 Marlowe transactions.

--- a/marlowe-plutus/cost-measurements/measure.R
+++ b/marlowe-plutus/cost-measurements/measure.R
@@ -1,0 +1,163 @@
+require(data.table)
+require(magrittr)
+
+require(ggplot2)
+
+raw <- fread("marlowe-semantics-rpacb.tsv", integer64="numeric")
+results <-
+  melt(
+    raw[, .(`TxId`, `Steps`=`Reference CPU`, `Memory`=`Reference Memory`)]
+  , id.vars=c("TxId")
+  , measure.variables=c("CPU", "Memory")
+  , variable.name="Cost"
+  , value.name="Value"
+  ) %>% suppressWarnings
+results[, `Case`:="Production"]
+
+for (f in dir(pattern="marlowe-semantics-.*.tsv")) {
+  raw <- fread(f, integer64="numeric")
+  caseResults <-
+    melt(
+      raw[, .(`TxId`, `Steps`=`Measured CPU`, `Memory`=`Measured Memory`)]
+    , id.vars=c("TxId")
+    , measure.variables=c("CPU", "Memory")
+    , variable.name="Cost"
+    , value.name="Value"
+    ) %>% suppressWarnings
+    caseResults[, `Case`:=substr(f, 19, 23)]
+  results <- rbind(results, caseResults)
+}
+
+results[, `:=`(
+  `Precondition`=grepl("r",`Case`,fixed=TRUE)
+  , `Positive Balance`=grepl("p",`Case`,fixed=TRUE)
+  , `Duplicate Accounts`=grepl("a",`Case`,fixed=TRUE)
+  , `Duplicate Choices`=grepl("c",`Case`,fixed=TRUE)
+  , `Duplicate Bindings`=grepl("b",`Case`,fixed=TRUE)
+  )
+]
+results[`Case` == "Production", `:=`(
+    `Precondition`=NA
+  , `Positive Balance`=NA
+  , `Duplicate Accounts`=NA
+  , `Duplicate Choices`=NA
+  , `Duplicate Bindings`=NA
+  )
+]
+
+write.table(results, file="full.tsv", sep="\t", row.names=FALSE)
+
+results %>% summary
+
+summaryResults <-
+  results[, .(
+      Minimum=min(`Value`)
+    , Mean=mean(`Value`)
+    , Median=median(`Value`)
+    , Maximum=max(`Value`)
+    ), by=.(
+      `Cost`
+    , `Case`
+    , `Precondition`
+    , `Positive Balance`
+    , `Duplicate Accounts`
+    , `Duplicate Choices`
+    , `Duplicate Bindings`
+    )
+  ]
+
+write.table(summaryResults, file="summary.tsv", sep="\t", row.names=FALSE)
+
+summaryResults %>% head
+
+relativeResults <- summaryResults[`Case`!="Production"]
+relativeResults[
+  `Cost`=="Steps"
+, `:=`(
+    `Minimum`=`Minimum`/summaryResults[`Cost`=="Steps"&`Case`=="Production",`Minimum`]
+   ,`Mean`=`Mean`/summaryResults[`Cost`=="Steps"&`Case`=="Production",`Mean`]
+   ,`Median`=`Median`/summaryResults[`Cost`=="Steps"&`Case`=="Production",`Median`]
+   ,`Maximum`=`Maximum`/summaryResults[`Cost`=="Steps"&`Case`=="Production",`Maximum`]
+   )
+]
+relativeResults[
+  `Cost`=="Memory"
+, `:=`(
+    `Minimum`=`Minimum`/summaryResults[`Cost`=="Memory"&`Case`=="Production",`Minimum`]
+   ,`Mean`=`Mean`/summaryResults[`Cost`=="Memory"&`Case`=="Production",`Mean`]
+   ,`Median`=`Median`/summaryResults[`Cost`=="Memory"&`Case`=="Production",`Median`]
+   ,`Maximum`=`Maximum`/summaryResults[`Cost`=="Memory"&`Case`=="Production",`Maximum`]
+   )
+]
+
+write.table(summaryResults, file="relative.tsv", sep="\t", row.names=FALSE)
+
+summary(relativeResults)
+
+relativeResults %>% head
+
+rp <- function(n, x) paste(n, "=", round(100*x,2), "%", sep="")
+
+mkNode <- function(case, x0, x1, x2, x3) {
+  rp <- function(n, x) paste(n, sprintf("%.1f%%", 100*x), sep="=")
+  paste(case, " [label=\"", case, "|{", paste(rp("min", x0), rp("avg", x1), rp("med", x2), rp("max", x3), sep="|"), "}\"]", sep="")
+}
+
+accept <- function(from, to) {
+  from < to && length(unique(tstrsplit(paste(from,to,sep=""),split=""))) == nchar(from) + 1
+}
+
+differs <- function(a, b) do.call(setdiff, strsplit(c(a, b), split = ""))
+
+prelude <-
+  data.table(
+    Line=c(
+      "digraph memory {"
+    , "fontname=\"monospace\""
+    , "node [shape=record,fontname=\"monospace\"]"
+    , "edge [fontname=\"monospace\"]"
+    , "ranksep=1"
+    , "measurements [label=\"Marlowe\\nsemantics\\nvalidator\\nmemory|{min=minimum|avg=mean|med=median|max=maximum}\"]"
+    , "production [label=\"Production|{min=100.0%|avg=100.0%|med=100.0%|max=100.0%}\"]"
+    , "cabal [label=\"Cabal\\nflags|{r = +check-preconditions|R = -check-preconditions|p = +check-positive-balances|P = -check-positive-balances|a = +check-duplicate-accounts|A = -check-duplicate-accounts|c = +check-duplicate-choices|C = -check-duplicate-choices|b = +check-duplicate-bindings|B = -check-duplicate-bindings}\"]"
+    , "production -> rpacb [label=\"Plutus\\n1.15.0.0\\ncompiler\"]"
+    )
+  )
+
+postlude <-
+  data.table(
+    Line=c(
+      "}"
+    )
+  )
+
+writeDot <- function(cost) {
+  nodes <-
+    relativeResults[
+    , .(
+        `Cost`
+      , `Line`=mapply(mkNode, `Case`, `Minimum`, `Mean`, `Median`, `Maximum`)
+      )
+    ]
+  cases <- relativeResults[, unique(`Case`)]
+  links <-
+  CJ(Cost=relativeResults[, unique(`Cost`)], From=cases, To=cases)[
+      mapply(accept, From, To)
+    , .(
+        `Cost`
+      , `Line`=paste(From, " -> ", To, " [label=", mapply(differs, To, From), "]", sep="")
+      )
+    ]
+  write.table(rbind(
+      prelude
+    , nodes[`Cost`==cost, .(`Line`)]
+    , links[`Cost`==cost, .(`Line`)]
+    , postlude
+  ), file=paste(cost, "dot", sep="."), quote=FALSE, row.names=FALSE, col.names=FALSE)
+}
+
+writeDot("Memory")
+
+writeDot("Steps")
+
+

--- a/marlowe-plutus/cost-measurements/measure.sh
+++ b/marlowe-plutus/cost-measurements/measure.sh
@@ -80,5 +80,5 @@ R CMD BATCH measure.R
 
 dot -Tsvg -o Memory.svg Memory.dot
 dot -Tpng -o Memory.png Memory.dot
-dot -Tsvg -o Steps.svg Memory.dot
-dot -Tpng -o Steps.png Memory.dot
+dot -Tsvg -o Steps.svg Steps.dot
+dot -Tpng -o Steps.png Steps.dot

--- a/marlowe-plutus/cost-measurements/measure.sh
+++ b/marlowe-plutus/cost-measurements/measure.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -i bash -p "rWrapper.override{packages = [ rPackages.data_table rPackages.magrittr rPackages.ggplot2 ];}" -p graphviz
+# shellcheck shell=bash
+
+echo "Run this script from its folder."
+
+for r in r R
+do
+  for p in p P
+  do
+    for a in a A
+    do
+      for c in c C
+      do
+        for b in b B
+        do
+          if [[ "$r" == "r" ]]
+          then
+            FLAGS="+check-preconditions"
+          else
+            FLAGS="-check-preconditions"
+          fi
+          if [[ "$p" == "p" ]]
+          then
+            FLAGS="$FLAGS +check-positive-balances"
+          else
+            FLAGS="$FLAGS -check-positive-balances"
+          fi
+          if [[ "$a" == "a" ]]
+          then
+            FLAGS="$FLAGS +check-duplicate-accounts"
+          else
+            FLAGS="$FLAGS -check-duplicate-accounts"
+          fi
+          if [[ "$c" == "c" ]]
+          then
+            FLAGS="$FLAGS +check-duplicate-choices"
+          else
+            FLAGS="$FLAGS -check-duplicate-choices"
+          fi
+  	  if [[ "$b" == "b" ]]
+  	  then
+  	    FLAGS="$FLAGS +check-duplicate-bindings"
+  	  else
+  	    FLAGS="$FLAGS -check-duplicate-bindings"
+  	  fi
+  	  LABEL="$r$p$a$c$b"
+	  if [[ -e "marlowe-semantics-$LABEL.tsv" ]]
+	  then 
+	    echo "LABEL=$LABEL already computed."
+	  else
+  	    set -e
+  	    echo
+  	    echo "FLAGS=$FLAGS"
+  	    echo
+	    cabal build .. --flags="$FLAGS"
+  	    set +e
+  	    echo
+  	    echo "LABEL=$LABEL"
+  	    echo
+  	    cabal test marlowe-plutus --flags="$FLAGS" >& "$LABEL.log"
+  	    cabal run marlowe-validators --flags="$FLAGS" && mv out/marlowe-semantics.tsv "marlowe-semantics-$LABEL.tsv"
+	  fi
+        done
+      done
+    done
+  done
+done
+
+echo "Writing results:"
+echo "- full.tsv = raw dataset"
+echo "- summary.tsv = statistical summary (absolute)"
+echo "- relative.tsv = statistical summary (relative)"
+echo "- Memory.svg = Galois lattice of Plutus memory results (SVG)"
+echo "- Memory.png = Galois lattice of Plutus memory results (PNG)"
+echo "- Steps.svg = Galois lattice of Plutus steps results (SVG)"
+echo "- Steps.png = Galois lattice of Plutus steps results (PNG)"
+
+R CMD BATCH measure.R
+
+dot -Tsvg -o Memory.svg Memory.dot
+dot -Tpng -o Memory.png Memory.dot
+dot -Tsvg -o Steps.svg Memory.dot
+dot -Tpng -o Steps.png Memory.dot

--- a/marlowe-plutus/marlowe-plutus.cabal
+++ b/marlowe-plutus/marlowe-plutus.cabal
@@ -34,6 +34,41 @@ flag trace-plutus
   default:     False
   manual:      True
 
+flag check-preconditions
+  description:
+    Validator checks whether preconditions are satisfied for the Marlowe state.
+
+  default:     True
+  manual:      False
+
+flag check-positive-balances
+  description:
+    Validator checks whether any account balances are non-positive in the Marlowe state.
+
+  default:     True
+  manual:      False
+
+flag check-duplicate-accounts
+  description:
+    Validator checks whether any accounts are duplicated in the Marlowe state.
+
+  default:     True
+  manual:      False
+
+flag check-duplicate-choices
+  description:
+    Validator checks whether any choices are duplicated in the Marlowe state.
+
+  default:     True
+  manual:      False
+
+flag check-duplicate-bindings
+  description:
+    Validator checks whether any bound values are duplicated in the Marlowe state.
+
+  default:     True
+  manual:      False
+
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -50,6 +85,30 @@ common lang
     -Wall -Wnoncanonical-monad-instances -Wincomplete-uni-patterns
     -Wincomplete-record-updates -Wredundant-constraints -Widentities
     -Werror
+
+  if flag(trace-plutus)
+    cpp-options: -DTRACE_PLUTUS
+    ghc-options:
+      -fforce-recomp -fplugin-opt
+      PlutusTx.Plugin:conservative-optimisation
+
+  else
+    ghc-options: -fforce-recomp -fplugin-opt PlutusTx.Plugin:remove-trace
+
+  if flag(check-preconditions)
+    cpp-options: -DCHECK_PRECONDITIONS
+
+  if flag(check-positive-balances)
+    cpp-options: -DCHECK_POSITIVE_BALANCES
+
+  if flag(check-duplicate-accounts)
+    cpp-options: -DCHECK_DUPLICATE_ACCOUNTS
+
+  if flag(check-duplicate-choices)
+    cpp-options: -DCHECK_DUPLICATE_CHOICES
+
+  if flag(check-duplicate-bindings)
+    cpp-options: -DCHECK_DUPLICATE_BINDINGS
 
 library
   import:          lang
@@ -74,15 +133,6 @@ library
     Language.Marlowe.Plutus.RoleTokens
     Language.Marlowe.Plutus.RoleTokens.Types
     Language.Marlowe.Plutus.Semantics
-
-  if flag(trace-plutus)
-    cpp-options: -DTRACE_PLUTUS
-    ghc-options:
-      -fforce-recomp -fplugin-opt
-      PlutusTx.Plugin:conservative-optimisation
-
-  else
-    ghc-options: -fforce-recomp -fplugin-opt PlutusTx.Plugin:remove-trace
 
 executable marlowe-validators
   import:         lang
@@ -165,14 +215,6 @@ test-suite marlowe-plutus
   build-tool-depends: hspec-discover:hspec-discover
   ghc-options:        -threaded
 
-  if flag(trace-plutus)
-    cpp-options: -DTRACE_PLUTUS
-
-  else
-    ghc-options:
-      -fplugin-opt PlutusTx.Plugin:remove-trace -fplugin-opt
-      PlutusTx.Plugin:conservative-optimisation
-
 executable marlowe-plutus-tester
   import:             lang
   hs-source-dirs:     test
@@ -227,8 +269,3 @@ executable marlowe-charli3
     , plutus-tx-plugin
 
   ghc-options:    -threaded
-
-  if flag(trace-plutus)
-
-  else
-    ghc-options: -fplugin-opt PlutusTx.Plugin:remove-trace

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Semantics.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Semantics.hs
@@ -1,3 +1,5 @@
+{- FOURMOLU_DISABLE -}
+
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DerivingStrategies #-}

--- a/marlowe-plutus/test/Language/Marlowe/PlutusSpec.hs
+++ b/marlowe-plutus/test/Language/Marlowe/PlutusSpec.hs
@@ -1,3 +1,5 @@
+{- FOURMOLU_DISABLE -}
+
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,7 +14,7 @@ cabalProject:
     cabal-fmt.extraOptions = "--no-tabular";
     nixpkgs-fmt.enable = true;
     shellcheck.enable = true;
-    fourmolu.enable = true;
+    fourmolu.enable = false;
     hlint.enable = true;
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,7 +14,8 @@ cabalProject:
     cabal-fmt.extraOptions = "--no-tabular";
     nixpkgs-fmt.enable = true;
     shellcheck.enable = true;
-    fourmolu.enable = false;
+    fourmolu.enable = true;
+    fourmolu.extraOptions = "-o XCPP";
     hlint.enable = true;
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -15,7 +15,7 @@ cabalProject:
     nixpkgs-fmt.enable = true;
     shellcheck.enable = true;
     fourmolu.enable = true;
-    fourmolu.extraOptions = "-o XCPP";
+    fourmolu.extraOptions = "-o -XCPP";
     hlint.enable = true;
   };
 }


### PR DESCRIPTION
This adds five cabal flags to optionally suppress certain checks in the Marlowe semantics validator:
- `check-preconditions`
- `check-positive-balances`
- `check-duplicate-accounts`
- `check-duplicate-choices`
- `check-duplicate-bindings`