### PR TITLE
PLT-7586 [DO NOT MERGE] Marlowe semantics validator with `PlutusTx.AsData`

### DIFF
--- a/marlowe-plutus/marlowe-plutus.cabal
+++ b/marlowe-plutus/marlowe-plutus.cabal
@@ -69,6 +69,13 @@ flag check-duplicate-bindings
   default:     True
   manual:      False
 
+flag plutus-asdata
+  description:
+    Experimental! Use alternative implementation relying on `PlutusTx.asData`.
+
+  default:     False
+  manual:      True
+
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -120,6 +127,7 @@ library
     , flat
     , lens
     , marlowe-cardano ==0.2.1.0
+    , newtype-generics
     , plutus-core ==1.15.0.0
     , plutus-ledger-api ==1.15.0.0
     , plutus-tx ==1.15.0.0
@@ -128,11 +136,18 @@ library
 
   exposed-modules:
     Language.Marlowe.Plutus
+    Language.Marlowe.Plutus.Alt.ScriptTypes
+    Language.Marlowe.Plutus.Alt.Semantics
+    Language.Marlowe.Plutus.Alt.Semantics.Types
+    Language.Marlowe.Plutus.Alt.Semantics.Types.Address
     Language.Marlowe.Plutus.OpenRoles
     Language.Marlowe.Plutus.RolePayout
     Language.Marlowe.Plutus.RoleTokens
     Language.Marlowe.Plutus.RoleTokens.Types
     Language.Marlowe.Plutus.Semantics
+
+  if flag(plutus-asdata)
+    cpp-options: -DPLUTUS_ASDATA
 
 executable marlowe-validators
   import:         lang

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/ScriptTypes.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/ScriptTypes.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ImportQualifiedPost #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- | Marlowe validators.
+--
+-- Module      :  $Headers
+-- License     :  Apache 2.0
+--
+-- Stability   :  Experimental
+-- Portability :  Portable
+module Language.Marlowe.Plutus.Alt.ScriptTypes (
+  -- * Types
+  MarloweInput,
+  MarloweTxInput (..),
+
+  -- * Utilities
+  marloweTxInputsFromInputs,
+) where
+
+import GHC.Generics (Generic)
+import Language.Marlowe.Plutus.Alt.Semantics.Types as Semantics
+import PlutusTx (makeIsDataIndexed, makeLift)
+import PlutusTx.Prelude as PlutusTxPrelude hiding (traceError, traceIfFalse)
+import Prelude qualified as Haskell
+
+-- | Input to a Marlowe transaction.
+type MarloweInput = [MarloweTxInput]
+
+-- | A single input applied in the Marlowe semantics validator.
+data MarloweTxInput
+  = Input InputContent
+  | MerkleizedTxInput InputContent BuiltinByteString
+  deriving stock (Haskell.Show, Haskell.Eq, Generic)
+
+-- | Convert semantics input to transaction input.
+marloweTxInputFromInput :: Input -> MarloweTxInput
+marloweTxInputFromInput (NormalInput i) = Input i
+marloweTxInputFromInput (MerkleizedInput i h _) = MerkleizedTxInput i h
+
+-- | Convert semantics inputs to transaction inputs.
+marloweTxInputsFromInputs :: [Input] -> [MarloweTxInput]
+marloweTxInputsFromInputs = fmap marloweTxInputFromInput
+
+-- Lifting data types to Plutus Core
+makeLift ''MarloweTxInput
+makeIsDataIndexed ''MarloweTxInput [('Input, 0), ('MerkleizedTxInput, 1)]

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics.hs
@@ -1,0 +1,760 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+-- truly mysterious issues here
+{-# OPTIONS_GHC -fmax-simplifier-iterations=0 #-}
+-- O0 turns these off
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+
+-- | = Marlowe: financial contracts domain specific language for blockchain
+--
+--   Here we present a reference implementation of Marlowe, domain-specific language targeted at
+--   the execution of financial contracts in the style of Peyton Jones et al
+--   on Cardano.
+--
+--   This is the Haskell implementation of Marlowe semantics for Cardano.
+--
+--   == Semantics
+--
+--   Semantics is based on <https://github.com/input-output-hk/marlowe/blob/stable/src/Semantics.hs>
+--
+--   Marlowe Contract execution is a chain of transactions,
+--   where remaining contract and its state is passed through /Datum/,
+--   and actions (i.e. /Choices/) are passed as
+--   /Redeemer Script/
+--
+--   /Validation Script/ is always the same Marlowe interpreter implementation, available below.
+module Language.Marlowe.Plutus.Alt.Semantics (
+  -- * Semantics
+  MarloweData (MarloweData, marloweParams, marloweState, marloweContract),
+  MarloweParams (..),
+  Payment (..),
+  TransactionInput (..),
+  TransactionOutput (..),
+  computeTransaction,
+  playTrace,
+
+  -- * Supporting Functions
+  addMoneyToAccount,
+  applyAction,
+  applyAllInputs,
+  applyCases,
+  applyInput,
+  convertReduceWarnings,
+  evalObservation,
+  evalValue,
+  fixInterval,
+  getContinuation,
+  giveMoney,
+  moneyInAccount,
+  playTraceAux,
+  reduceContractStep,
+  reduceContractUntilQuiescent,
+  refundOne,
+  updateMoneyInAccount,
+
+  -- * Supporting Types
+  ApplyAction (..),
+  ApplyAllResult (..),
+  ApplyResult (..),
+  ApplyWarning (..),
+  ReduceEffect (..),
+  ReduceResult (..),
+  ReduceStepResult (..),
+  ReduceWarning (..),
+  TransactionError (..),
+  TransactionWarning (..),
+
+  -- * Utility Functions
+  allBalancesArePositive,
+  contractLifespanUpperBound,
+  isClose,
+  notClose,
+  paymentMoney,
+  totalBalance,
+) where
+
+import Data.Data (Data)
+import GHC.Generics (Generic)
+import Language.Marlowe.Plutus.Alt.Semantics.Types
+import PlutusLedgerApi.V2 (POSIXTime (..))
+import PlutusTx (FromData, ToData, UnsafeFromData)
+import PlutusTx.AsData (asData)
+import PlutusTx.IsData (makeIsDataIndexed)
+import PlutusTx.Lift (makeLift)
+import PlutusTx.Prelude (
+  AdditiveGroup ((-)),
+  AdditiveSemigroup ((+)),
+  Bool (..),
+  Eq (..),
+  Integer,
+  Maybe (..),
+  MultiplicativeSemigroup ((*)),
+  Ord (max, min, (<), (<=), (>), (>=)),
+  all,
+  foldMap,
+  foldr,
+  fst,
+  negate,
+  not,
+  otherwise,
+  reverse,
+  snd,
+  ($),
+  (&&),
+  (++),
+  (||),
+ )
+
+import qualified PlutusLedgerApi.V2 as Val
+import qualified PlutusTx.AssocMap as Map
+import qualified PlutusTx.Builtins as Builtins
+import qualified Prelude as Haskell
+
+-- | Payment occurs during 'Pay' contract evaluation, and
+--     when positive balances are payed out on contract closure.
+data Payment = Payment AccountId Payee Token Integer
+  deriving stock (Haskell.Eq, Haskell.Show, Data)
+
+-- | Extract the money value from a payment.
+paymentMoney :: Payment -> Money
+paymentMoney (Payment _ _ (Token cur tok) amt) = Val.singleton cur tok amt
+
+-- | Effect of 'reduceContractStep' computation
+data ReduceEffect
+  = ReduceWithPayment Payment
+  | ReduceNoPayment
+  deriving stock (Haskell.Show, Data)
+
+-- | Warning during 'reduceContractStep'
+data ReduceWarning
+  = ReduceNoWarning
+  | ReduceNonPositivePay AccountId Payee Token Integer
+  | ReducePartialPay AccountId Payee Token Integer Integer
+  | --                                      ^ src    ^ dest       ^ paid ^ expected
+    ReduceShadowing ValueId Integer Integer
+  | --                                     oldVal ^  newVal ^
+    ReduceAssertionFailed
+  deriving stock (Haskell.Show, Data)
+
+-- | Result of 'reduceContractStep'
+data ReduceStepResult
+  = Reduced ReduceWarning ReduceEffect State Contract
+  | NotReduced
+  | AmbiguousTimeIntervalReductionError
+  deriving stock (Haskell.Show, Data)
+
+-- | Result of 'reduceContractUntilQuiescent'
+data ReduceResult
+  = ContractQuiescent Bool [ReduceWarning] [Payment] State Contract
+  | RRAmbiguousTimeIntervalError
+  deriving stock (Haskell.Show, Data)
+
+-- | Warning of 'applyCases'
+data ApplyWarning
+  = ApplyNoWarning
+  | ApplyNonPositiveDeposit Party AccountId Token Integer
+  deriving stock (Haskell.Show, Data)
+
+-- | Result of 'applyCases'
+data ApplyResult
+  = Applied ApplyWarning State Contract
+  | ApplyNoMatchError
+  | ApplyHashMismatch
+  deriving stock (Haskell.Show, Data)
+
+-- | Result of 'applyAllInputs'
+data ApplyAllResult
+  = ApplyAllSuccess Bool [TransactionWarning] [Payment] State Contract
+  | ApplyAllNoMatchError
+  | ApplyAllAmbiguousTimeIntervalError
+  | ApplyAllHashMismatch
+  deriving stock (Haskell.Show, Data)
+
+-- | Warnings during transaction computation
+data TransactionWarning
+  = TransactionNonPositiveDeposit Party AccountId Token Integer
+  | TransactionNonPositivePay AccountId Payee Token Integer
+  | TransactionPartialPay AccountId Payee Token Integer Integer
+  | --                                                 ^ src    ^ dest     ^ paid   ^ expected
+    TransactionShadowing ValueId Integer Integer
+  | --                                                 oldVal ^  newVal ^
+    TransactionAssertionFailed
+  deriving stock (Haskell.Show, Generic, Haskell.Eq, Data)
+
+-- | Transaction error
+data TransactionError
+  = TEAmbiguousTimeIntervalError
+  | TEApplyNoMatchError
+  | TEIntervalError IntervalError
+  | TEUselessTransaction
+  | TEHashMismatch
+  deriving stock (Haskell.Show, Generic, Haskell.Eq, Data)
+
+-- | Marlowe transaction input.
+data TransactionInput = TransactionInput
+  { txInterval :: TimeInterval
+  , txInputs :: [Input]
+  }
+  deriving stock (Haskell.Show, Haskell.Eq, Data)
+
+-- | Marlowe transaction output.
+data TransactionOutput
+  = TransactionOutput
+      { txOutWarnings :: [TransactionWarning]
+      , txOutPayments :: [Payment]
+      , txOutState :: State
+      , txOutContract :: Contract
+      }
+  | Error TransactionError
+  deriving stock (Haskell.Show, Data)
+
+-- | Parameters constant during the course of a contract.
+newtype MarloweParams = MarloweParams {rolesCurrency :: CurrencySymbol}
+  deriving stock (Haskell.Show, Generic, Haskell.Eq, Haskell.Ord, Data)
+
+makeIsDataIndexed ''MarloweParams [('MarloweParams, 0)]
+
+asData
+  [d|
+    -- \| This data type is a content of a contract's /Datum/
+    data MarloweData = MarloweData
+      { marloweParams :: MarloweParams
+      , marloweState :: State
+      , marloweContract :: Contract
+      }
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Show, Haskell.Eq)
+    |]
+
+{-# INLINEABLE MarloweData #-}
+
+-- | Checks 'interval' and trims it if necessary.
+fixInterval :: TimeInterval -> State -> IntervalResult
+fixInterval interval state =
+  case interval of
+    (low, high)
+      | high < low -> IntervalError (InvalidInterval interval)
+      | otherwise ->
+          let curMinTime = minTime state
+              -- newLow is both new "low" and new "minTime" (the lower bound for slotNum)
+              newLow = max low curMinTime
+              -- We know high is greater or equal than newLow (prove)
+              curInterval = (newLow, high)
+              env = Environment{timeInterval = curInterval}
+              newState = state{minTime = newLow}
+           in if high < curMinTime
+                then IntervalError (IntervalInPastError curMinTime interval)
+                else IntervalTrimmed env newState
+
+-- | Evaluates @Value@ given current @State@ and @Environment@.
+evalValue :: Environment -> State -> Value Observation -> Integer
+evalValue env state value =
+  let eval = evalValue env state
+   in case value of
+        AvailableMoney accId token -> moneyInAccount accId token (accounts state)
+        Constant integer -> integer
+        NegValue val -> negate (eval val)
+        AddValue lhs rhs -> eval lhs + eval rhs
+        SubValue lhs rhs -> eval lhs - eval rhs
+        MulValue lhs rhs -> eval lhs * eval rhs
+        DivValue lhs rhs ->
+          let n = eval lhs
+              d = eval rhs
+           in if d == 0
+                then 0
+                else n `Builtins.quotientInteger` d
+        ChoiceValue choiceId ->
+          -- SCP-5126: Given the precondition that `choices` contains no
+          -- duplicate entries, this lookup behaves identically to
+          -- Marlowe's Isabelle semantics given the precondition that
+          -- the initial state's `choices` in Isabelle was sorted and
+          -- did not contain duplicate entries.
+          case Map.lookup choiceId (choices state) of
+            Just x -> x
+            Nothing -> 0
+        TimeIntervalStart -> getPOSIXTime (fst (timeInterval env))
+        TimeIntervalEnd -> getPOSIXTime (snd (timeInterval env))
+        UseValue valId ->
+          -- SCP-5126: Given the precondition that `boundValues` contains
+          -- no duplicate entries, this lookup behaves identically to
+          -- Marlowe's Isabelle semantics given the precondition that
+          -- the initial state's `boundValues` in Isabelle was sorted
+          -- and did not contain duplicate entries.
+          case Map.lookup valId (boundValues state) of
+            Just x -> x
+            Nothing -> 0
+        Cond cond thn els -> if evalObservation env state cond then eval thn else eval els
+
+-- | Evaluate 'Observation' to 'Bool'.
+evalObservation :: Environment -> State -> Observation -> Bool
+evalObservation env state obs =
+  let evalObs = evalObservation env state
+      evalVal = evalValue env state
+   in case obs of
+        AndObs lhs rhs -> evalObs lhs && evalObs rhs
+        OrObs lhs rhs -> evalObs lhs || evalObs rhs
+        NotObs subObs -> not (evalObs subObs)
+        -- SCP-5126: Given the precondition that `choices` contains no
+        -- duplicate entries, this membership test behaves identically
+        -- to Marlowe's Isabelle semantics given the precondition that
+        -- the initial state's `choices` in Isabelle was sorted and did
+        -- not contain duplicate entries.
+        ChoseSomething choiceId -> choiceId `Map.member` choices state
+        ValueGE lhs rhs -> evalVal lhs >= evalVal rhs
+        ValueGT lhs rhs -> evalVal lhs > evalVal rhs
+        ValueLT lhs rhs -> evalVal lhs < evalVal rhs
+        ValueLE lhs rhs -> evalVal lhs <= evalVal rhs
+        ValueEQ lhs rhs -> evalVal lhs == evalVal rhs
+        TrueObs -> True
+        FalseObs -> False
+
+-- | Pick the first account with money in it.
+refundOne :: Accounts -> Maybe ((Party, Token, Integer), Accounts)
+refundOne accounts = case Map.toList accounts of
+  [] -> Nothing
+  -- SCP-5126: The return value of this function differs from
+  -- Isabelle semantics in that it returns the least-recently
+  -- added account-token combination rather than the first
+  -- lexicographically ordered one. Also, the sequence
+  -- `Map.fromList . tail . Map.toList` preserves the
+  -- invariants of order and non-duplication.
+  ((accId, token), balance) : rest ->
+    if balance > 0
+      then Just ((accId, token, balance), Map.fromList rest)
+      else refundOne (Map.fromList rest)
+
+-- | Obtains the amount of money available an account.
+moneyInAccount :: AccountId -> Token -> Accounts -> Integer
+moneyInAccount accId token accounts =
+  -- SCP-5126: Given the precondition that `accounts` contains
+  -- no duplicate entries, this lookup behaves identically to
+  -- Marlowe's Isabelle semantics given the precondition that
+  -- the initial state's `accounts` in Isabelle was sorted and
+  -- did not contain duplicate entries.
+  case Map.lookup (accId, token) accounts of
+    Just x -> x
+    Nothing -> 0
+
+-- | Sets the amount of money available in an account.
+updateMoneyInAccount :: AccountId -> Token -> Integer -> Accounts -> Accounts
+updateMoneyInAccount accId token amount =
+  -- SCP-5126: Given the precondition that `accounts` contains
+  -- no duplicate entries, this deletion or insertion behaves
+  -- identically (aside from internal ordering) to Marlowe's
+  -- Isabelle semantics given the precondition that the initial
+  -- state's `accounts` in Isabelle was sorted and did not
+  -- contain duplicate entries.
+  if amount <= 0 then Map.delete (accId, token) else Map.insert (accId, token) amount
+
+-- | Add the given amount of money to an account (only if it is positive).
+--   Return the updated Map.
+addMoneyToAccount :: AccountId -> Token -> Integer -> Accounts -> Accounts
+addMoneyToAccount accId token amount accounts =
+  let balance = moneyInAccount accId token accounts
+      newBalance = balance + amount
+   in if amount <= 0
+        then accounts
+        else updateMoneyInAccount accId token newBalance accounts
+
+-- | Gives the given amount of money to the given payee.
+--   Returns the appropriate effect and updated accounts.
+giveMoney :: AccountId -> Payee -> Token -> Integer -> Accounts -> (ReduceEffect, Accounts)
+giveMoney accountId payee token amount accounts =
+  let newAccounts = case payee of
+        Party _ -> accounts
+        Account accId -> addMoneyToAccount accId token amount accounts
+   in (ReduceWithPayment (Payment accountId payee token amount), newAccounts)
+
+-- | Carry a step of the contract with no inputs.
+reduceContractStep :: Environment -> State -> Contract -> ReduceStepResult
+reduceContractStep env state contract = case contract of
+  -- SCP-5126: Although `refundOne` refunds accounts-token combinations
+  -- in least-recently-added order and Isabelle semantics requires that
+  -- they be refunded in lexicographic order, `reduceContractUntilQuiescent`
+  -- ensures that the `Close` pattern will be executed until `accounts`
+  -- is empty. Thus, the net difference between the behavior here and the
+  -- Isabelle semantics is that the `ContractQuiescent` resulting from
+  -- `reduceContractUntilQuiescent` will contain payments in a different
+  -- order.
+  Close -> case refundOne (accounts state) of
+    Just ((party, token, amount), newAccounts) ->
+      let newState = state{accounts = newAccounts}
+       in Reduced ReduceNoWarning (ReduceWithPayment (Payment party (Party party) token amount)) newState Close
+    Nothing -> NotReduced
+  Pay accId payee tok val cont ->
+    let amountToPay = evalValue env state val
+     in if amountToPay <= 0
+          then
+            let warning = ReduceNonPositivePay accId payee tok amountToPay
+             in Reduced warning ReduceNoPayment state cont
+          else
+            let balance = moneyInAccount accId tok (accounts state)
+                paidAmount = min balance amountToPay
+                newBalance = balance - paidAmount
+                newAccs = updateMoneyInAccount accId tok newBalance (accounts state)
+                warning =
+                  if paidAmount < amountToPay
+                    then ReducePartialPay accId payee tok paidAmount amountToPay
+                    else ReduceNoWarning
+                (payment, finalAccs) = giveMoney accId payee tok paidAmount newAccs
+                newState = state{accounts = finalAccs}
+             in Reduced warning payment newState cont
+  If obs cont1 cont2 ->
+    let cont = if evalObservation env state obs then cont1 else cont2
+     in Reduced ReduceNoWarning ReduceNoPayment state cont
+  When _ timeout cont ->
+    let (startTime, endTime) = timeInterval env
+     in -- if timeout in future – do not reduce
+        if endTime < timeout
+          then NotReduced
+          else -- if timeout in the past – reduce to timeout continuation
+
+            if timeout <= startTime
+              then Reduced ReduceNoWarning ReduceNoPayment state cont
+              else -- if timeout in the time range – issue an ambiguity error
+                AmbiguousTimeIntervalReductionError
+  Let valId val cont ->
+    let evaluatedValue = evalValue env state val
+        boundVals = boundValues state
+        -- SCP-5126: Given the precondition that `boundValues` contains
+        -- no duplicate entries, this insertion behaves identically
+        -- (aside from internal ordering) to Marlowe's Isabelle semantics
+        -- given the precondition that the initial state's `boundValues`
+        -- in Isabelle was sorted and did not contain duplicate entries.
+        newState = state{boundValues = Map.insert valId evaluatedValue boundVals}
+        -- SCP-5126: Given the precondition that `boundValues` contains
+        -- no duplicate entries, this lookup behaves identically to
+        -- Marlowe's Isabelle semantics given the precondition that the
+        -- initial state's `boundValues` in Isabelle was sorted and did
+        -- not contain duplicate entries.
+        warn = case Map.lookup valId boundVals of
+          Just oldVal -> ReduceShadowing valId oldVal evaluatedValue
+          Nothing -> ReduceNoWarning
+     in Reduced warn ReduceNoPayment newState cont
+  Assert obs cont ->
+    let warning =
+          if evalObservation env state obs
+            then ReduceNoWarning
+            else ReduceAssertionFailed
+     in Reduced warning ReduceNoPayment state cont
+
+-- | Reduce a contract until it cannot be reduced more.
+reduceContractUntilQuiescent :: Environment -> State -> Contract -> ReduceResult
+reduceContractUntilQuiescent env state contract =
+  let reductionLoop
+        :: Bool -> Environment -> State -> Contract -> [ReduceWarning] -> [Payment] -> ReduceResult
+      reductionLoop reduced env state contract warnings payments =
+        case reduceContractStep env state contract of
+          Reduced warning effect newState cont ->
+            let newWarnings = case warning of
+                  ReduceNoWarning -> warnings
+                  _ -> warning : warnings
+                newPayments = case effect of
+                  ReduceWithPayment payment -> payment : payments
+                  ReduceNoPayment -> payments
+             in reductionLoop True env newState cont newWarnings newPayments
+          AmbiguousTimeIntervalReductionError -> RRAmbiguousTimeIntervalError
+          -- this is the last invocation of reductionLoop, so we can reverse lists
+          NotReduced -> ContractQuiescent reduced (reverse warnings) (reverse payments) state contract
+   in reductionLoop False env state contract [] []
+
+-- | Result of applying an action to a contract.
+data ApplyAction
+  = AppliedAction ApplyWarning State
+  | NotAppliedAction
+  deriving stock (Haskell.Show, Data)
+
+-- | Try to apply a single input content to a single action.
+applyAction :: Environment -> State -> InputContent -> Action -> ApplyAction
+applyAction env state (IDeposit accId1 party1 tok1 amount) (Deposit accId2 party2 tok2 val) =
+  if accId1 == accId2 && party1 == party2 && tok1 == tok2 && amount == evalValue env state val
+    then
+      let warning =
+            if amount > 0
+              then ApplyNoWarning
+              else ApplyNonPositiveDeposit party2 accId2 tok2 amount
+          newAccounts = addMoneyToAccount accId1 tok1 amount (accounts state)
+          newState = state{accounts = newAccounts}
+       in AppliedAction warning newState
+    else NotAppliedAction
+applyAction _ state (IChoice choId1 choice) (Choice choId2 bounds) =
+  if choId1 == choId2 && inBounds choice bounds
+    then -- SCP-5126: Given the precondition that `choices` contains no
+    -- duplicate entries, this insertion behaves identically (aside
+    -- from internal ordering) to Marlowe's Isabelle semantics
+    -- given the precondition that the initial state's `choices`
+    -- in Isabelle was sorted and did not contain duplicate entries.
+
+      let newState = state{choices = Map.insert choId1 choice (choices state)}
+       in AppliedAction ApplyNoWarning newState
+    else NotAppliedAction
+applyAction env state INotify (Notify obs)
+  | evalObservation env state obs = AppliedAction ApplyNoWarning state
+applyAction _ _ _ _ = NotAppliedAction
+
+-- | Try to get a continuation from a pair of Input and Case.
+getContinuation :: Input -> Case Contract -> Maybe Contract
+getContinuation (NormalInput _) (Case _ continuation) = Just continuation
+getContinuation (MerkleizedInput _ inputContinuationHash continuation) (MerkleizedCase _ continuationHash) =
+  if inputContinuationHash == continuationHash
+    then Just continuation
+    else Nothing
+getContinuation _ _ = Nothing
+
+-- | Try to apply an input to a list of cases, accepting the first match.
+applyCases :: Environment -> State -> Input -> [Case Contract] -> ApplyResult
+applyCases env state input (headCase : tailCases) =
+  let inputContent = getInputContent input :: InputContent
+      action = getAction headCase :: Action
+      maybeContinuation = getContinuation input headCase :: Maybe Contract
+   in case applyAction env state inputContent action of
+        AppliedAction warning newState ->
+          -- Note that this differs from Isabelle semantics because
+          -- the Cardano semantics includes merkleization.
+          case maybeContinuation of
+            Just continuation -> Applied warning newState continuation
+            Nothing -> ApplyHashMismatch
+        NotAppliedAction -> applyCases env state input tailCases
+applyCases _ _ _ [] = ApplyNoMatchError
+
+-- | Apply a single @Input@ to a current contract.
+applyInput :: Environment -> State -> Input -> Contract -> ApplyResult
+applyInput env state input (When cases _ _) = applyCases env state input cases
+applyInput _ _ _ _ = ApplyNoMatchError
+
+-- | Propagate 'ReduceWarning' to 'TransactionWarning'.
+convertReduceWarnings :: [ReduceWarning] -> [TransactionWarning]
+convertReduceWarnings =
+  foldr
+    ( \warn acc -> case warn of -- Note that `foldr` is used here for efficiency, differing from Isabelle.
+        ReduceNoWarning -> acc
+        ReduceNonPositivePay accId payee tok amount ->
+          TransactionNonPositivePay accId payee tok amount : acc
+        ReducePartialPay accId payee tok paid expected ->
+          TransactionPartialPay accId payee tok paid expected : acc
+        ReduceShadowing valId oldVal newVal ->
+          TransactionShadowing valId oldVal newVal : acc
+        ReduceAssertionFailed ->
+          TransactionAssertionFailed : acc
+    )
+    []
+
+-- | Apply a list of Inputs to the contract.
+applyAllInputs :: Environment -> State -> Contract -> [Input] -> ApplyAllResult
+applyAllInputs env state contract inputs =
+  let applyAllLoop
+        :: Bool
+        -> Environment
+        -> State
+        -> Contract
+        -> [Input]
+        -> [TransactionWarning]
+        -> [Payment]
+        -> ApplyAllResult
+      applyAllLoop contractChanged env state contract inputs warnings payments =
+        case reduceContractUntilQuiescent env state contract of
+          RRAmbiguousTimeIntervalError -> ApplyAllAmbiguousTimeIntervalError
+          ContractQuiescent reduced reduceWarns pays curState cont ->
+            let warnings' = warnings ++ convertReduceWarnings reduceWarns
+                payments' = payments ++ pays
+             in case inputs of
+                  [] ->
+                    ApplyAllSuccess
+                      (contractChanged || reduced)
+                      warnings'
+                      payments'
+                      curState
+                      cont
+                  (input : rest) -> case applyInput env curState input cont of
+                    Applied applyWarn newState cont' ->
+                      applyAllLoop
+                        True
+                        env
+                        newState
+                        cont'
+                        rest
+                        (warnings' ++ convertApplyWarning applyWarn)
+                        payments'
+                    ApplyNoMatchError -> ApplyAllNoMatchError
+                    ApplyHashMismatch -> ApplyAllHashMismatch
+   in applyAllLoop False env state contract inputs [] []
+  where
+    convertApplyWarning :: ApplyWarning -> [TransactionWarning]
+    convertApplyWarning warn =
+      case warn of
+        ApplyNoWarning -> []
+        ApplyNonPositiveDeposit party accId tok amount ->
+          [TransactionNonPositiveDeposit party accId tok amount]
+
+-- | Check if a contract is just @Close@.
+isClose :: Contract -> Bool
+isClose Close = True
+isClose _ = False
+
+-- | Check if a contract is not just @Close@.
+notClose :: Contract -> Bool
+notClose Close = False
+notClose _ = True
+
+-- | Try to compute outputs of a transaction given its inputs, a contract, and it's @State@
+computeTransaction :: TransactionInput -> State -> Contract -> TransactionOutput
+computeTransaction tx state contract =
+  let inputs = txInputs tx
+   in case fixInterval (txInterval tx) state of
+        IntervalTrimmed env fixState -> case applyAllInputs env fixState contract inputs of
+          ApplyAllSuccess reduced warnings payments newState cont ->
+            if not reduced && (notClose contract || (Map.null $ accounts state))
+              then Error TEUselessTransaction
+              else
+                TransactionOutput
+                  { txOutWarnings = warnings
+                  , txOutPayments = payments
+                  , txOutState = newState
+                  , txOutContract = cont
+                  }
+          ApplyAllNoMatchError -> Error TEApplyNoMatchError
+          ApplyAllAmbiguousTimeIntervalError -> Error TEAmbiguousTimeIntervalError
+          ApplyAllHashMismatch -> Error TEHashMismatch
+        IntervalError error -> Error (TEIntervalError error)
+
+-- | Run a set of inputs starting from the results of a transaction, reporting the new result.
+playTraceAux :: TransactionOutput -> [TransactionInput] -> TransactionOutput
+playTraceAux res [] = res
+playTraceAux
+  TransactionOutput
+    { txOutWarnings = warnings
+    , txOutPayments = payments
+    , txOutState = state
+    , txOutContract = cont
+    }
+  (h : t) =
+    let transRes = computeTransaction h state cont
+     in case transRes of
+          TransactionOutput{..} ->
+            playTraceAux
+              TransactionOutput
+                { txOutPayments = payments ++ txOutPayments
+                , txOutWarnings = warnings ++ txOutWarnings
+                , txOutState
+                , txOutContract
+                }
+              t
+          Error _ -> transRes
+playTraceAux err@(Error _) _ = err
+
+-- | Run a set of inputs starting from a contract and empty state, reporting the result.
+playTrace :: POSIXTime -> Contract -> [TransactionInput] -> TransactionOutput
+playTrace minTime c =
+  playTraceAux
+    TransactionOutput
+      { txOutWarnings = []
+      , txOutPayments = []
+      , txOutState = emptyState minTime
+      , txOutContract = c
+      }
+
+-- | Calculates an upper bound for the maximum lifespan of a contract (assuming is not merkleized)
+contractLifespanUpperBound :: Contract -> POSIXTime
+contractLifespanUpperBound contract = case contract of
+  Close -> 0
+  Pay _ _ _ _ cont -> contractLifespanUpperBound cont
+  If _ contract1 contract2 ->
+    max (contractLifespanUpperBound contract1) (contractLifespanUpperBound contract2)
+  When cases timeout subContract ->
+    let contractsLifespans = [contractLifespanUpperBound c | Case _ c <- cases]
+     in Haskell.maximum (timeout : contractLifespanUpperBound subContract : contractsLifespans)
+  Let _ _ cont -> contractLifespanUpperBound cont
+  Assert _ cont -> contractLifespanUpperBound cont
+
+-- | Total the balance in all accounts.
+totalBalance :: Accounts -> Money
+totalBalance accounts =
+  foldMap
+    (\((_, Token cur tok), balance) -> Val.singleton cur tok balance)
+    (Map.toList accounts)
+
+-- | Check that all accounts have positive balance.
+allBalancesArePositive :: State -> Bool
+allBalancesArePositive State{..} = all (\(_, balance) -> balance > 0) (Map.toList accounts)
+
+instance Eq Payment where
+  {-# INLINEABLE (==) #-}
+  Payment a1 p1 t1 i1 == Payment a2 p2 t2 i2 = a1 == a2 && p1 == p2 && t1 == t2 && i1 == i2
+
+instance Eq ReduceWarning where
+  {-# INLINEABLE (==) #-}
+  ReduceNoWarning == ReduceNoWarning = True
+  ReduceNoWarning == _ = False
+  ReduceNonPositivePay acc1 p1 tn1 a1 == ReduceNonPositivePay acc2 p2 tn2 a2 =
+    acc1 == acc2 && p1 == p2 && tn1 == tn2 && a1 == a2
+  ReduceNonPositivePay{} == _ = False
+  ReducePartialPay acc1 p1 tn1 a1 e1 == ReducePartialPay acc2 p2 tn2 a2 e2 =
+    acc1 == acc2 && p1 == p2 && tn1 == tn2 && a1 == a2 && e1 == e2
+  ReducePartialPay{} == _ = False
+  ReduceShadowing v1 old1 new1 == ReduceShadowing v2 old2 new2 =
+    v1 == v2 && old1 == old2 && new1 == new2
+  ReduceShadowing{} == _ = False
+  ReduceAssertionFailed == ReduceAssertionFailed = True
+  ReduceAssertionFailed == _ = False
+
+instance Eq ReduceEffect where
+  {-# INLINEABLE (==) #-}
+  ReduceNoPayment == ReduceNoPayment = True
+  ReduceNoPayment == _ = False
+  ReduceWithPayment p1 == ReduceWithPayment p2 = p1 == p2
+  ReduceWithPayment _ == _ = False
+
+-- Functions that used in Plutus Core must be inlineable,
+-- so their code is available for PlutusTx compiler.
+{-# INLINEABLE fixInterval #-}
+{-# INLINEABLE evalValue #-}
+{-# INLINEABLE evalObservation #-}
+{-# INLINEABLE refundOne #-}
+{-# INLINEABLE moneyInAccount #-}
+{-# INLINEABLE updateMoneyInAccount #-}
+{-# INLINEABLE addMoneyToAccount #-}
+{-# INLINEABLE giveMoney #-}
+{-# INLINEABLE reduceContractStep #-}
+{-# INLINEABLE reduceContractUntilQuiescent #-}
+{-# INLINEABLE applyAction #-}
+{-# INLINEABLE getContinuation #-}
+{-# INLINEABLE applyCases #-}
+{-# INLINEABLE applyInput #-}
+{-# INLINEABLE convertReduceWarnings #-}
+{-# INLINEABLE applyAllInputs #-}
+{-# INLINEABLE isClose #-}
+{-# INLINEABLE notClose #-}
+{-# INLINEABLE computeTransaction #-}
+{-# INLINEABLE contractLifespanUpperBound #-}
+{-# INLINEABLE totalBalance #-}
+
+-- Lifting data types to Plutus Core
+makeLift ''IntervalError
+makeLift ''IntervalResult
+makeLift ''Payment
+makeLift ''ReduceEffect
+makeLift ''ReduceWarning
+makeLift ''ReduceStepResult
+makeLift ''ReduceResult
+makeLift ''ApplyWarning
+makeLift ''ApplyResult
+makeLift ''TransactionWarning
+makeLift ''ApplyAllResult
+makeLift ''TransactionError
+makeLift ''TransactionOutput
+makeLift ''MarloweParams
+makeLift ''MarloweData

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics/Types.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics/Types.hs
@@ -1,0 +1,399 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ViewPatterns #-}
+-- Probably could use a more specific flag but not sure what, need
+-- to stop GHC inserting a clever recursive go function with no unfolding
+{-# OPTIONS_GHC -O0 #-}
+{-# OPTIONS_GHC -Wno-name-shadowing #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-simplifiable-class-constraints #-}
+-- O0 turns these off
+{-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
+{-# OPTIONS_GHC -fno-specialise #-}
+{-# OPTIONS_GHC -fno-strictness #-}
+
+-- | Types for Marlowe semantics
+module Language.Marlowe.Plutus.Alt.Semantics.Types (
+  -- * Type Aliases
+  AccountId,
+  Accounts,
+  ChoiceName,
+  ChosenNum,
+  Money,
+  TimeInterval,
+  Timeout,
+
+  -- * Contract Types
+  Action (Choice, Deposit, Notify),
+  Bound (..),
+  Case (Case, MerkleizedCase),
+  ChoiceId (ChoiceId),
+  Contract (Close, Let, Assert, If, Pay, When),
+  CurrencySymbol (..),
+  Environment (..),
+  Input (NormalInput, MerkleizedInput),
+  InputContent (IChoice, IDeposit, INotify),
+  IntervalResult (..),
+  Observation (ValueEQ, ValueGE, ValueGT, ValueLT, ValueLE, TrueObs, OrObs, NotObs, FalseObs, ChoseSomething, AndObs),
+  Party (Role, Address),
+  Payee (Account, Party),
+  State (State, choices, accounts, boundValues, minTime),
+  Token (Token),
+  TokenName (..),
+  Value (
+    TimeIntervalStart,
+    TimeIntervalEnd,
+    UseValue,
+    SubValue,
+    NegValue,
+    MulValue,
+    DivValue,
+    Cond,
+    ChoiceValue,
+    AvailableMoney,
+    AddValue,
+    Constant
+  ),
+  ValueId (..),
+
+  -- * Error Types
+  IntervalError (..),
+
+  -- * Utility Functions
+  emptyState,
+  getAction,
+  getInputContent,
+  inBounds,
+) where
+
+import Control.Newtype.Generics (Newtype)
+import Data.Data (Data)
+import Data.String (IsString (..))
+import GHC.Generics (Generic)
+import Language.Marlowe.Plutus.Alt.Semantics.Types.Address (Network)
+import PlutusLedgerApi.V2 (CurrencySymbol, POSIXTime (..), TokenName)
+import PlutusTx.AsData (asData)
+import PlutusTx.AssocMap (Map)
+import PlutusTx.IsData (FromData, ToData, UnsafeFromData, makeIsDataIndexed)
+import PlutusTx.Lift (makeLift)
+import PlutusTx.Prelude (
+  Bool (..),
+  BuiltinByteString,
+  Eq (..),
+  Integer,
+  Ord ((<=), (>=)),
+  any,
+  (&&),
+ )
+
+import qualified PlutusLedgerApi.V1.Value as Val
+import qualified PlutusLedgerApi.V2 as Ledger (
+  Address (..),
+  Credential (..),
+  PubKeyHash (..),
+  ScriptHash (..),
+  StakingCredential (..),
+ )
+import qualified PlutusTx.AssocMap as Map
+import qualified Prelude as Haskell
+
+deriving stock instance Data POSIXTime
+deriving stock instance Data Ledger.Address
+deriving stock instance Data Ledger.Credential
+deriving stock instance Data Ledger.PubKeyHash
+deriving stock instance Data Ledger.ScriptHash
+deriving stock instance Data Ledger.StakingCredential
+
+asData
+  [d|
+    -- \| A Party to a contract.
+    data Party
+      = Address Network Ledger.Address
+      | -- \^ Party identified by a network address.
+        Role TokenName
+      -- \^ Party identified by a role token name.
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+-- | A party's internal account in a contract.
+type AccountId = Party
+
+-- | A timeout in a contract.
+type Timeout = POSIXTime
+
+-- | A multi-asset value.
+type Money = Val.Value
+
+-- | The name of a choice in a contract.
+type ChoiceName = BuiltinByteString
+
+-- | A numeric choice in a contract.
+type ChosenNum = Integer
+
+-- | The time validity range for a Marlowe transaction, inclusive of both endpoints.
+type TimeInterval = (POSIXTime, POSIXTime)
+
+asData
+  [d|
+    -- \| Choices – of integers – are identified by ChoiceId which combines a name for
+    -- the choice with the Party who had made the choice.
+    data ChoiceId = ChoiceId BuiltinByteString Party
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| Token - represents a currency or token, it groups
+    --   a pair of a currency symbol and token name.
+    data Token = Token CurrencySymbol TokenName
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+-- | The accounts in a contract.
+type Accounts = Map (AccountId, Token) Integer
+
+-- | Values, as defined using Let ar e identified by name,
+--   and can be used by 'UseValue' construct.
+newtype ValueId = ValueId BuiltinByteString
+  deriving (IsString, Haskell.Show) via TokenName
+  deriving stock (Haskell.Eq, Haskell.Ord, Generic, Data)
+  deriving anyclass (Newtype)
+  deriving newtype (Eq)
+
+makeIsDataIndexed ''ValueId [('ValueId, 0)]
+
+asData
+  [d|
+    -- \| Values include some quantities that change with time,
+    --   including “the time interval”, “the current balance of an account”,
+    --   and any choices that have already been made.
+    --
+    --   Values can also be scaled, and combined using addition, subtraction, and negation.
+    data Value a
+      = AvailableMoney AccountId Token
+      | Constant Integer
+      | NegValue (Value a)
+      | AddValue (Value a) (Value a)
+      | SubValue (Value a) (Value a)
+      | MulValue (Value a) (Value a)
+      | DivValue (Value a) (Value a)
+      | ChoiceValue ChoiceId
+      | TimeIntervalStart
+      | TimeIntervalEnd
+      | UseValue ValueId
+      | Cond a (Value a) (Value a)
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| Observations are Boolean values derived by comparing values,
+    --   and can be combined using the standard Boolean operators.
+    --
+    --   It is also possible to observe whether any choice has been made
+    --   (for a particular identified choice).
+    data Observation
+      = AndObs Observation Observation
+      | OrObs Observation Observation
+      | NotObs Observation
+      | ChoseSomething ChoiceId
+      | ValueGE (Value Observation) (Value Observation)
+      | ValueGT (Value Observation) (Value Observation)
+      | ValueLT (Value Observation) (Value Observation)
+      | ValueLE (Value Observation) (Value Observation)
+      | ValueEQ (Value Observation) (Value Observation)
+      | TrueObs
+      | FalseObs
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| The (inclusive) bound on a choice number.
+    data Bound = Bound Integer Integer
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| Actions happen at particular points during execution.
+    --   Three kinds of action are possible:
+    --
+    --   * A @Deposit n p v@ makes a deposit of value @v@ into account @n@ belonging to party @p@.
+    --
+    --   * A choice is made for a particular id with a list of bounds on the values that are acceptable.
+    --     For example, @[(0, 0), (3, 5]@ offers the choice of one of 0, 3, 4 and 5.
+    --
+    --   * The contract is notified that a particular observation be made.
+    --     Typically this would be done by one of the parties,
+    --     or one of their wallets acting automatically.
+    data Action
+      = Deposit AccountId Party Token (Value Observation)
+      | Choice ChoiceId [Bound]
+      | Notify Observation
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| A payment can be made to one of the parties to the contract,
+    --   or to one of the accounts of the contract,
+    --   and this is reflected in the definition.
+    data Payee
+      = Account AccountId
+      | Party Party
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| A case is a branch of a when clause, guarded by an action.
+    --   The continuation of the contract may be merkleized or not.
+    --
+    --   Plutus doesn't support mutually recursive data types yet.
+    --   datatype Case is mutually recursive with @Contract@
+    data Case a
+      = Case Action a
+      | MerkleizedCase Action BuiltinByteString
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+-- | Extract the @Action@ from a @Case@.
+getAction :: (ToData a, UnsafeFromData a) => Case a -> Action
+getAction (Case action _) = action
+getAction (MerkleizedCase action _) = action
+{-# INLINEABLE getAction #-}
+
+asData
+  [d|
+    -- \| Marlowe has six ways of building contracts.
+    --   Five of these – 'Pay', 'Let', 'If', 'When' and 'Assert' –
+    --   build a complex contract from simpler contracts, and the sixth, 'Close',
+    --   is a simple contract.
+    --   At each step of execution, as well as returning a new state and continuation contract,
+    --   it is possible that effects – payments – and warnings can be generated too.
+    data Contract
+      = Close
+      | Pay AccountId Payee Token (Value Observation) Contract
+      | If Observation Contract Contract
+      | When [Case Contract] Timeout Contract
+      | Let ValueId (Value Observation) Contract
+      | Assert Observation Contract
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| Marlowe contract internal state. Stored in a /Datum/ of a transaction output.
+    data State = State
+      { accounts :: Accounts
+      , choices :: Map ChoiceId ChosenNum
+      , boundValues :: Map ValueId Integer
+      , minTime :: POSIXTime
+      }
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+{-# INLINEABLE State #-}
+
+-- | Execution environment. Contains a time interval of a transaction.
+newtype Environment = Environment {timeInterval :: TimeInterval}
+  deriving stock (Haskell.Show, Haskell.Eq, Haskell.Ord, Data)
+  deriving newtype (Eq)
+
+makeIsDataIndexed ''Environment [('Environment, 0)]
+
+asData
+  [d|
+    -- \| Input for a Marlowe contract. Correspond to expected 'Action's.
+    data InputContent
+      = IDeposit AccountId Party Token Integer
+      | IChoice ChoiceId ChosenNum
+      | INotify
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+asData
+  [d|
+    -- \| Input to a contract, which may include the merkleized continuation
+    --   of the contract and its hash.
+    data Input
+      = NormalInput InputContent
+      | MerkleizedInput InputContent BuiltinByteString Contract
+      deriving stock (Generic, Data)
+      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show, Eq)
+    |]
+
+-- | Extract the content of input.
+getInputContent :: Input -> InputContent
+getInputContent (NormalInput inputContent) = inputContent
+getInputContent (MerkleizedInput inputContent _ _) = inputContent
+{-# INLINEABLE getInputContent #-}
+
+-- | Time interval errors.
+--   'InvalidInterval' means @slotStart > slotEnd@, and
+--   'IntervalInPastError' means time interval is in the past, relative to the contract.
+--
+--   These errors should never occur, but we are always prepared.
+data IntervalError
+  = InvalidInterval TimeInterval
+  | IntervalInPastError POSIXTime TimeInterval
+  deriving stock (Haskell.Show, Haskell.Eq, Generic, Data)
+
+-- | Result of 'fixInterval'
+data IntervalResult
+  = IntervalTrimmed Environment State
+  | IntervalError IntervalError
+  deriving stock (Haskell.Show, Generic, Data)
+
+-- | Empty State for a given minimal 'POSIXTime'
+emptyState :: POSIXTime -> State
+emptyState sn =
+  State
+    { accounts = Map.empty
+    , choices = Map.empty
+    , boundValues = Map.empty
+    , minTime = sn
+    }
+{-# INLINEABLE emptyState #-}
+
+-- | Check if a 'num' is withint a list of inclusive bounds.
+inBounds :: ChosenNum -> [Bound] -> Bool
+inBounds num = any (\(Bound l u) -> num >= l && num <= u)
+{-# INLINEABLE inBounds #-}
+
+makeLift ''Party
+makeLift ''ChoiceId
+makeLift ''Token
+makeLift ''ValueId
+makeLift ''Value
+makeLift ''Observation
+makeLift ''Bound
+makeLift ''Action
+makeLift ''Case
+makeLift ''Payee
+makeLift ''Contract
+makeLift ''State
+makeLift ''Environment
+makeLift ''InputContent
+makeLift ''Input

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics/Types/Address.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Alt/Semantics/Types/Address.hs
@@ -1,0 +1,19 @@
+-----------------------------------------------------------------------------
+--
+-- Module      :  $Headers
+-- License     :  Apache 2.0
+--
+-- Stability   :  Experimental
+-- Portability :  Portable
+--
+
+-----------------------------------------------------------------------------
+
+-- | Address types for Marlowe.
+module Language.Marlowe.Plutus.Alt.Semantics.Types.Address (
+  -- * Types
+  Network,
+) where
+
+-- | Type of network.
+type Network = Bool


### PR DESCRIPTION
This experimental version of the Marlowe semantics validator uses `PlutusTx.AsData` for the Marlowesemantics types. Compile with the cabal flag `+plutus-asdata`.