### PR TITLE
PLT-9055 Removed `PlutusTx.asData` for `Action`.

### DIFF
--- a/changelog.d/20231222_093546_brian.bush_PLT_7583.md
+++ b/changelog.d/20231222_093546_brian.bush_PLT_7583.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed cabal flag for using `PlutusTx.asData` for `Action`.

--- a/marlowe-plutus/marlowe-plutus.cabal
+++ b/marlowe-plutus/marlowe-plutus.cabal
@@ -79,11 +79,6 @@ flag asdata-case
   default:     True
   manual:      True
 
-flag asdata-action
-  description: Use `PlutusTx.asData` for `Action`.
-  default:     True
-  manual:      True
-
 common lang
   default-language:   Haskell2010
   default-extensions:
@@ -155,9 +150,6 @@ library
 
   if flag(asdata-case)
     cpp-options: -DASDATA_CASE
-
-  if flag(asdata-action)
-    cpp-options: -DASDATA_ACTION
 
 executable marlowe-validators
   import:         lang

--- a/marlowe-plutus/src/Language/Marlowe/Plutus/Semantics/Types.hs
+++ b/marlowe-plutus/src/Language/Marlowe/Plutus/Semantics/Types.hs
@@ -81,7 +81,7 @@ import PlutusTx.Lift (makeLift)
 import PlutusTx.Prelude hiding (encodeUtf8, mapM, (<$>), (<*>), (<>))
 import qualified Prelude as Haskell
 
-#if defined(ASDATA_CASE) || defined(ASDATA_ACTION)
+#ifdef ASDATA_CASE
 import Data.Data (Data)
 import PlutusTx (FromData, ToData, UnsafeFromData, makeIsDataIndexed)
 import PlutusTx.AsData (asData)
@@ -225,33 +225,6 @@ data Bound = Bound Integer Integer
 
 makeIsDataIndexed ''Bound [('Bound, 0)]
 
-#ifdef ASDATA_ACTION
-
-asData
-  [d|
-    -- | Actions happen at particular points during execution.
-    --   Three kinds of action are possible:
-    --
-    --   * A @Deposit n p v@ makes a deposit of value @v@ into account @n@ belonging to party @p@.
-    --
-    --   * A choice is made for a particular id with a list of bounds on the values that are acceptable.
-    --     For example, @[(0, 0), (3, 5]@ offers the choice of one of 0, 3, 4 and 5.
-    --
-    --   * The contract is notified that a particular observation be made.
-    --     Typically this would be done by one of the parties,
-    --     or one of their wallets acting automatically.
-    --
-    --   Note that the @asData@ encompases an equivalent @makeIsDataIndexed ''Action [('Deposit, 0), ('Choice, 1), ('Notify, 2)]@.
-    data Action
-      = Deposit AccountId Party Token (Value Observation)
-      | Choice ChoiceId [Bound]
-      | Notify Observation
-      deriving stock (Generic, Data)
-      deriving newtype (ToData, FromData, UnsafeFromData, Haskell.Eq, Haskell.Ord, Haskell.Show)
-    |]
-
-#else
-
 -- | Actions happen at particular points during execution.
 --   Three kinds of action are possible:
 --
@@ -270,8 +243,6 @@ data Action
   deriving stock (Haskell.Show, Generic, Haskell.Eq, Haskell.Ord)
 
 makeIsDataIndexed ''Action [('Deposit, 0), ('Choice, 1), ('Notify, 2)]
-
-#endif
 
 -- | A payment can be made to one of the parties to the contract,
 --   or to one of the accounts of the contract,

--- a/marlowe-plutus/test/Language/Marlowe/PlutusSpec.hs
+++ b/marlowe-plutus/test/Language/Marlowe/PlutusSpec.hs
@@ -187,10 +187,10 @@ import qualified Spec.Marlowe.Plutus.Types as PC
 checkPlutusLog :: Bool
 maxMarloweValidatorSize :: Int
 #ifdef TRACE_PLUTUS
-maxMarloweValidatorSize = 11_181
+maxMarloweValidatorSize = 11_251
 checkPlutusLog = True
 #else
-maxMarloweValidatorSize = 11_009
+maxMarloweValidatorSize = 11_079
 checkPlutusLog = False
 #endif
 
@@ -255,8 +255,8 @@ specForScript scripts@ScriptsInfo{semanticsValidatorHash, payoutValidatorHash} =
         -- APPROVED CHANGES TO MARLOWE'S SEMANTICS VALIDATOR. THIS HASH
         -- HAS IMPLICATIONS FOR VERSIONING, AUDIT, AND CONTRACT DISCOVERY.
         ( if checkPlutusLog
-            then "0fbbcf3598695461f5f36ac077a2854348f4a22d34e032758a19444b"
-            else "5389215e955cc19f61b25632dfacf4d6f0b775bbd5f92e17227ea99a"
+            then "7bbd48635695786d0c63b7a42cd888d2327a7a9b2340b2f09229e9be"
+            else "377325ad84a55ba0282d844dff2d5f0f18c33fd4a28a0a9d73c6f60d"
         )
   describe "Payout validator" do
     describe "Valid transactions" do


### PR DESCRIPTION
It turns out `asData` for `Action` is not longer needed, and can be counterproductive.