### PR TITLE
added aarch64-linux in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
   outputs = inputs: inputs.iogx.lib.mkFlake {
     inherit inputs;
     repoRoot = ./.;
-    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" "aarch64-linux" ];
     outputs = import ./nix/outputs.nix;
   };
 


### PR DESCRIPTION
Added the ability to compile the project in `aarch64-linux` (linked to https://github.com/input-output-hk/marlowe-cardano/pull/833)